### PR TITLE
feat(cc_sdk): add injectable DI setup to generate di_cc_sdk.config.dart

### DIFF
--- a/libraries/cc_sdk/lib/core/di/di_cc_sdk.dart
+++ b/libraries/cc_sdk/lib/core/di/di_cc_sdk.dart
@@ -1,0 +1,19 @@
+import 'package:get_it/get_it.dart';
+import 'package:injectable/injectable.dart';
+
+// This is the generated file from build_runner
+import 'di_cc_sdk.config.dart';
+
+/// Global service locator instance for the cc_sdk library.
+final GetIt ccSdkLocator = GetIt.instance;
+
+/// Configures and initializes all dependencies in the cc_sdk library.
+///
+/// Returns the configured [GetIt] instance.
+@InjectableInit(
+  initializerName: r'$initCcSdkDependencies',
+  preferRelativeImports: true,
+  asExtension: false,
+)
+GetIt configureCcSdkDependencies() =>
+    $initCcSdkDependencies(ccSdkLocator);

--- a/libraries/cc_sdk/lib/core/di/di_export.dart
+++ b/libraries/cc_sdk/lib/core/di/di_export.dart
@@ -1,0 +1,1 @@
+export 'di_cc_sdk.dart' show configureCcSdkDependencies;

--- a/libraries/cc_sdk/lib/core/di/module/cc_sdk_module.dart
+++ b/libraries/cc_sdk/lib/core/di/module/cc_sdk_module.dart
@@ -1,0 +1,34 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:injectable/injectable.dart';
+import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
+
+import '../../../data/datasources/local/cc_device_local_data_source.dart';
+import '../../helper/cc_network_helper.dart';
+import '../../network/network_info.dart';
+
+@module
+abstract class CcSdkModule {
+  @singleton
+  InternetConnection get internetConnection => InternetConnection();
+
+  @singleton
+  Connectivity get connectivity => Connectivity();
+
+  @singleton
+  DeviceInfoPlugin get deviceInfoPlugin => DeviceInfoPlugin();
+
+  @singleton
+  CcNetworkHelper networkHelper(InternetConnection connection) =>
+      CcNetworkHelper(connection);
+
+  @singleton
+  NetworkInfo networkInfo(Connectivity connectivity) =>
+      NetworkInfoImpl(connectivity);
+
+  @lazySingleton
+  CcDeviceLocalDataSource deviceLocalDataSource(
+    DeviceInfoPlugin deviceInfoPlugin,
+  ) =>
+      CcDeviceLocalDataSourceImpl(deviceInfoPlugin: deviceInfoPlugin);
+}

--- a/libraries/cc_sdk/lib/export_cc_sdk.dart
+++ b/libraries/cc_sdk/lib/export_cc_sdk.dart
@@ -1,3 +1,5 @@
+// Core DI
+export 'package:cc_sdk/core/di/di_export.dart';
 // Core Constants
 export 'package:cc_sdk/core/config/cc_app_track_info.dart';
 export 'package:cc_sdk/core/config/cc_feature_flags.dart';

--- a/libraries/cc_sdk/pubspec.yaml
+++ b/libraries/cc_sdk/pubspec.yaml
@@ -32,8 +32,10 @@ dependencies:
   flutter_udid: ^4.1.2
 
   get: ^4.7.3
+  get_it: ^9.2.1
   google_fonts: ^8.1.0
 
+  injectable: ^3.0.0
   internet_connection_checker_plus: ^3.0.0
   intl: ^0.20.2
 
@@ -52,6 +54,8 @@ dependencies:
   stack_trace: ^1.12.1
 
 dev_dependencies:
+  build_runner: ^2.15.0
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
+  injectable_generator: ^3.0.2

--- a/run/[cc_sdk].run.xml
+++ b/run/[cc_sdk].run.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="[cc_sdk]" type="ShConfigurationType" folderName="build__runner" singleton="false">
+    <option name="SCRIPT_TEXT" value="fvm dart run build_runner build --delete-conflicting-outputs" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$USER_HOME$/run.sh" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$/libraries/cc_sdk" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
## Summary

The `cc_sdk` library was missing the injectable/get_it DI setup entirely. This PR adds:

1. **Dependencies** — `get_it`, `injectable` + `build_runner`, `injectable_generator` in `pubspec.yaml`
2. **DI entry-point** — `di_cc_sdk.dart` with `@InjectableInit` annotation to trigger code generation
3. **`@module` class** — `CcSdkModule` that registers cc_sdk's core dependencies, so the generated `di_cc_sdk.config.dart` has actual registrations (like `di_app_config.config.dart`)
4. **IDE run config** — `[cc_sdk].run.xml` for running build_runner from the IDE

**Generated `di_cc_sdk.config.dart` now registers:**
- `InternetConnection`, `Connectivity`, `DeviceInfoPlugin` (singletons)
- `CcNetworkHelper`, `NetworkInfo` (singletons)
- `CcDeviceLocalDataSource` (lazy singleton)

**How to generate `di_cc_sdk.config.dart`:**

⚠️ Must be run from inside `libraries/cc_sdk/`, NOT from the project root.

```bash
cd libraries/cc_sdk
# If you see "0 outputs" or "skipped", delete .dart_tool first:
# Windows: rmdir /s /q .dart_tool
# Mac/Linux: rm -rf .dart_tool
fvm flutter pub get
fvm dart run build_runner build
```

Or use the `[cc_sdk]` run configuration in the IDE's `build__runner` folder.

## Review & Testing Checklist for Human
- [ ] Check for duplicate DI registrations — `CcNetworkHelper` is also registered in `AppConfigModule` (app_config), and `DeviceInfoPlugin` / `InternetConnection` are also in `InfrastructureModule` (main app). You may want to remove duplicates from consuming modules now that cc_sdk owns them.
- [ ] `cd libraries/cc_sdk && fvm flutter pub get && fvm dart run build_runner build` — verify `di_cc_sdk.config.dart` is generated with actual registrations
- [ ] Verify the main app compiles and runs correctly

### Notes
- If build_runner says "wrote 0 outputs" with everything "skipped", delete the `.dart_tool` directory and re-run `flutter pub get` + `build_runner build`.
- Each sub-package needs its own build_runner invocation. The project root build_runner does NOT generate files for sub-packages.


Link to Devin session: https://app.devin.ai/sessions/19231f86ba974cff92368ced763b9cc6
Requested by: @huytower