### PR TITLE
fix: add generated injectable .config.dart files for all modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,7 @@ migrate_working_dir/
 pubspec.lock
 .android/
 **/*.g.dart
-**/*.config.dart
+# **/*.config.dart  # Removed: injectable .config.dart files must be committed
 **/*.freezed.dart
 **/*.gr.dart
 

--- a/lib/core/di/inject/inject.config.dart
+++ b/lib/core/di/inject/inject.config.dart
@@ -1,0 +1,102 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
+
+// **************************************************************************
+// InjectableConfigGenerator
+// **************************************************************************
+
+// ignore_for_file: type=lint
+// coverage:ignore-file
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:cc_sdk/export_cc_sdk.dart' as _i54;
+import 'package:data/data/datasource/local/home/home_local_datasource.dart'
+    as _i199;
+import 'package:data/data/datasource/remote/home/home_remote_datasource.dart'
+    as _i67;
+import 'package:data/domain/repositories/home/home_repository.dart' as _i515;
+import 'package:data/domain/repositories/sample_code_fake_api/sample_code_fake_api_repositories.dart'
+    as _i872;
+import 'package:data/domain/usecases/home/get_home_data_usecase.dart' as _i5;
+import 'package:data/domain/usecases/home/refresh_home_data_usecase.dart'
+    as _i176;
+import 'package:data/domain/usecases/home/update_home_data_usecase.dart'
+    as _i15;
+import 'package:device_info_plus/device_info_plus.dart' as _i833;
+import 'package:get_it/get_it.dart' as _i174;
+import 'package:injectable/injectable.dart' as _i526;
+import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart'
+    as _i161;
+import 'package:mobile_flutter_template/core/di/module/infrastructure_module.dart'
+    as _i809;
+import 'package:mobile_flutter_template/presentation/home/di/home_dependency_module.dart'
+    as _i283;
+import 'package:mobile_flutter_template/presentation/home/presentation/bloc/home_bloc.dart'
+    as _i1047;
+import 'package:mobile_flutter_template/sample_code/bloc_simple_page/cubit/simple/simple_cubit.dart'
+    as _i576;
+import 'package:mobile_flutter_template/sample_code/bloc_simple_page/cubit/simple/simple_cubit_interface.dart'
+    as _i312;
+import 'package:mobile_flutter_template/sample_code/bloc_simple_page/origin/advance/advance_bloc.dart'
+    as _i98;
+import 'package:mobile_flutter_template/sample_code/getx_simple_page/way_1/getx/get_view_controller.dart'
+    as _i866;
+
+extension GetItInjectableX on _i174.GetIt {
+  // initializes the registration of main-scope dependencies inside of GetIt
+  Future<_i174.GetIt> $initGetIt({
+    String? environment,
+    _i526.EnvironmentFilter? environmentFilter,
+  }) async {
+    final gh = _i526.GetItHelper(this, environment, environmentFilter);
+    final infrastructureModule = _$InfrastructureModule();
+    final homeDependencyModule = _$HomeDependencyModule();
+    gh.singleton<_i161.InternetConnection>(
+      () => infrastructureModule.connectionChecker,
+    );
+    gh.singleton<_i833.DeviceInfoPlugin>(
+      () => infrastructureModule.deviceInfoPlugin,
+    );
+    await gh.singletonAsync<_i54.CcDeviceEntity>(
+      () => infrastructureModule.deviceModel,
+      preResolve: true,
+    );
+    gh.lazySingleton<_i199.HomeLocalDataSource>(
+      () => homeDependencyModule.homeLocalDataSource,
+    );
+    gh.lazySingleton<_i67.HomeRemoteDataSource>(
+      () => homeDependencyModule.homeRemoteDataSource,
+    );
+    gh.lazySingleton<_i515.HomeRepository>(
+      () => homeDependencyModule.homeRepository,
+    );
+    gh.lazySingleton<_i5.GetHomeDataUseCase>(
+      () => homeDependencyModule.getHomeDataUseCase,
+    );
+    gh.lazySingleton<_i15.UpdateHomeDataUseCase>(
+      () => homeDependencyModule.updateHomeDataUseCase,
+    );
+    gh.lazySingleton<_i176.RefreshHomeDataUseCase>(
+      () => homeDependencyModule.refreshHomeDataUseCase,
+    );
+    gh.lazySingleton<_i98.AdvanceBloc>(() => _i98.AdvanceBloc());
+    gh.lazySingleton<_i312.SimpleCubitInterface>(() => _i576.SimpleCubit());
+    gh.lazySingleton<_i866.GetViewController>(
+      () => _i866.GetViewController(
+        repository: gh<_i872.SampleCodeFakeApiImpl>(),
+      ),
+    );
+    gh.factory<_i1047.HomeBloc>(
+      () => _i1047.HomeBloc(
+        getHomeDataUseCase: gh<_i5.GetHomeDataUseCase>(),
+        updateHomeDataUseCase: gh<_i15.UpdateHomeDataUseCase>(),
+        refreshHomeDataUseCase: gh<_i176.RefreshHomeDataUseCase>(),
+      ),
+    );
+    return this;
+  }
+}
+
+class _$InfrastructureModule extends _i809.InfrastructureModule {}
+
+class _$HomeDependencyModule extends _i283.HomeDependencyModule {}

--- a/libraries/cc_sdk/lib/core/di/di_cc_sdk.config.dart
+++ b/libraries/cc_sdk/lib/core/di/di_cc_sdk.config.dart
@@ -1,0 +1,47 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
+
+// **************************************************************************
+// InjectableConfigGenerator
+// **************************************************************************
+
+// ignore_for_file: type=lint
+// coverage:ignore-file
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:connectivity_plus/connectivity_plus.dart' as _i895;
+import 'package:device_info_plus/device_info_plus.dart' as _i833;
+import 'package:get_it/get_it.dart' as _i174;
+import 'package:injectable/injectable.dart' as _i526;
+import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart'
+    as _i161;
+
+import '../../data/datasources/local/cc_device_local_data_source.dart' as _i627;
+import '../helper/cc_network_helper.dart' as _i260;
+import '../network/network_info.dart' as _i932;
+import 'module/cc_sdk_module.dart' as _i568;
+
+// initializes the registration of main-scope dependencies inside of GetIt
+_i174.GetIt $initCcSdkDependencies(
+  _i174.GetIt getIt, {
+  String? environment,
+  _i526.EnvironmentFilter? environmentFilter,
+}) {
+  final gh = _i526.GetItHelper(getIt, environment, environmentFilter);
+  final ccSdkModule = _$CcSdkModule();
+  gh.singleton<_i161.InternetConnection>(() => ccSdkModule.internetConnection);
+  gh.singleton<_i895.Connectivity>(() => ccSdkModule.connectivity);
+  gh.singleton<_i833.DeviceInfoPlugin>(() => ccSdkModule.deviceInfoPlugin);
+  gh.lazySingleton<_i627.CcDeviceLocalDataSource>(
+    () => ccSdkModule.deviceLocalDataSource(gh<_i833.DeviceInfoPlugin>()),
+  );
+  gh.singleton<_i932.NetworkInfo>(
+    () => ccSdkModule.networkInfo(gh<_i895.Connectivity>()),
+  );
+  gh.singleton<_i260.CcNetworkHelper>(
+    () => ccSdkModule.networkHelper(gh<_i161.InternetConnection>()),
+  );
+  return getIt;
+}
+
+class _$CcSdkModule extends _i568.CcSdkModule {}

--- a/libraries/features/lib/core/di/injection.config.dart
+++ b/libraries/features/lib/core/di/injection.config.dart
@@ -1,0 +1,89 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
+
+// **************************************************************************
+// InjectableConfigGenerator
+// **************************************************************************
+
+// ignore_for_file: type=lint
+// coverage:ignore-file
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:get_it/get_it.dart' as _i174;
+import 'package:injectable/injectable.dart' as _i526;
+import 'package:shared_preferences/shared_preferences.dart' as _i460;
+
+import '../../auth/biometric/data/datasources/local/cc_biometric_auth_datasource.dart'
+    as _i382;
+import '../../auth/biometric/data/repositories/cc_biometric_auth_repository_impl.dart'
+    as _i960;
+import '../../auth/biometric/domain/repositories/cc_biometric_auth_repository.dart'
+    as _i100;
+import '../../auth/biometric/domain/usecases/cc_authenticate_with_biometrics.dart'
+    as _i693;
+import '../../auth/biometric/presentation/bloc/biometric_bloc.dart' as _i596;
+import '../../counter/data/datasources/counter_local_data_source.dart' as _i276;
+import '../../counter/data/repositories/counter_repository_impl.dart' as _i104;
+import '../../counter/domain/repositories/counter_repository.dart' as _i532;
+import '../../counter/domain/usecases/get_counter_use_case.dart' as _i571;
+import '../../counter/domain/usecases/increment_counter_use_case.dart' as _i405;
+import '../../counter/presentation/bloc/counter_bloc.dart' as _i595;
+import 'module/external_module.dart' as _i423;
+
+// initializes the registration of main-scope dependencies inside of GetIt
+Future<_i174.GetIt> $initFeaturesGetIt(
+  _i174.GetIt getIt, {
+  String? environment,
+  _i526.EnvironmentFilter? environmentFilter,
+}) async {
+  final gh = _i526.GetItHelper(getIt, environment, environmentFilter);
+  final externalModule = _$ExternalModule();
+  await gh.factoryAsync<_i460.SharedPreferences>(
+    () => externalModule.sharedPreferences,
+    preResolve: true,
+  );
+  gh.lazySingleton<_i382.CcBiometricAuthDatasource>(
+    () => _i382.CcBiometricAuthDatasource(),
+  );
+  gh.lazySingleton<_i100.CcBiometricAuthRepository>(
+    () => _i960.CcBiometricAuthRepositoryImpl(
+      gh<_i382.CcBiometricAuthDatasource>(),
+    ),
+  );
+  gh.lazySingleton<_i276.CounterLocalDataSource>(
+    () => _i276.CounterLocalDataSourceImpl(
+      sharedPreferences: gh<_i460.SharedPreferences>(),
+    ),
+  );
+  gh.lazySingleton<_i693.CcAuthenticateWithBiometrics>(
+    () => _i693.CcAuthenticateWithBiometrics(
+      gh<_i100.CcBiometricAuthRepository>(),
+    ),
+  );
+  gh.lazySingleton<_i532.CounterRepository>(
+    () => _i104.CounterRepositoryImpl(
+      localDataSource: gh<_i276.CounterLocalDataSource>(),
+    ),
+  );
+  gh.factory<_i596.BiometricBloc>(
+    () => _i596.BiometricBloc(
+      gh<_i693.CcAuthenticateWithBiometrics>(),
+      gh<_i100.CcBiometricAuthRepository>(),
+    ),
+  );
+  gh.lazySingleton<_i571.GetCounterUseCase>(
+    () => _i571.GetCounterUseCase(gh<_i532.CounterRepository>()),
+  );
+  gh.lazySingleton<_i405.IncrementCounterUseCase>(
+    () => _i405.IncrementCounterUseCase(gh<_i532.CounterRepository>()),
+  );
+  gh.factory<_i595.CounterBloc>(
+    () => _i595.CounterBloc(
+      getCounterUseCase: gh<_i571.GetCounterUseCase>(),
+      incrementCounterUseCase: gh<_i405.IncrementCounterUseCase>(),
+    ),
+  );
+  return getIt;
+}
+
+class _$ExternalModule extends _i423.ExternalModule {}

--- a/modules/app_config/lib/core/di/di_app_config.config.dart
+++ b/modules/app_config/lib/core/di/di_app_config.config.dart
@@ -1,0 +1,59 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
+
+// **************************************************************************
+// InjectableConfigGenerator
+// **************************************************************************
+
+// ignore_for_file: type=lint
+// coverage:ignore-file
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:cc_sdk/core/helper/cc_network_helper.dart' as _i548;
+import 'package:get_it/get_it.dart' as _i174;
+import 'package:injectable/injectable.dart' as _i526;
+
+import '../../data/datasource/local/box/app_storage/cc_app_storage.dart'
+    as _i811;
+import '../../data/datasource/local/box/device_info/cc_device_info.dart'
+    as _i24;
+import '../../data/datasource/remote/app_version_api.dart' as _i65;
+import '../../data/repositories/app_config_repository_impl.dart' as _i701;
+import '../../domain/repositories/app_config_repository.dart' as _i79;
+import '../../domain/usecases/check_update_required.dart' as _i935;
+import '../../domain/usecases/get_app_config.dart' as _i897;
+import '../../domain/usecases/get_feature_flag.dart' as _i1044;
+import '../../domain/usecases/refresh_app_config.dart' as _i75;
+import 'module/dependencies.dart' as _i264;
+
+// initializes the registration of main-scope dependencies inside of GetIt
+_i174.GetIt $initAppConfigDependencies(
+  _i174.GetIt getIt, {
+  String? environment,
+  _i526.EnvironmentFilter? environmentFilter,
+}) {
+  final gh = _i526.GetItHelper(getIt, environment, environmentFilter);
+  final appConfigModule = _$AppConfigModule();
+  gh.singleton<_i548.CcNetworkHelper>(() => appConfigModule.networkHelper);
+  gh.lazySingleton<_i811.CcAppStorage>(() => appConfigModule.ccAppStorage);
+  gh.lazySingleton<_i24.CcDeviceInfo>(() => appConfigModule.ccDeviceInfo);
+  gh.lazySingleton<_i65.AppVersionAPI>(() => appConfigModule.appVersionService);
+  gh.lazySingleton<_i79.AppConfigRepository>(
+    () => _i701.AppConfigRepositoryImpl(gh<_i65.AppVersionAPI>()),
+  );
+  gh.lazySingleton<_i935.CheckUpdateRequired>(
+    () => _i935.CheckUpdateRequired(gh<_i79.AppConfigRepository>()),
+  );
+  gh.lazySingleton<_i897.GetAppConfig>(
+    () => _i897.GetAppConfig(gh<_i79.AppConfigRepository>()),
+  );
+  gh.lazySingleton<_i1044.GetFeatureFlag>(
+    () => _i1044.GetFeatureFlag(gh<_i79.AppConfigRepository>()),
+  );
+  gh.lazySingleton<_i75.RefreshAppConfig>(
+    () => _i75.RefreshAppConfig(gh<_i79.AppConfigRepository>()),
+  );
+  return getIt;
+}
+
+class _$AppConfigModule extends _i264.AppConfigModule {}

--- a/modules/data/lib/core/di/inject/data_inject.config.dart
+++ b/modules/data/lib/core/di/inject/data_inject.config.dart
@@ -1,0 +1,85 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
+
+// **************************************************************************
+// InjectableConfigGenerator
+// **************************************************************************
+
+// ignore_for_file: type=lint
+// coverage:ignore-file
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:data/core/di/module/data_module.dart' as _i532;
+import 'package:data/data/datasource/remote/comment/comment_remote.dart'
+    as _i574;
+import 'package:data/data/datasource/remote/crash_log/crash_log_remote.dart'
+    as _i313;
+import 'package:data/data/datasource/remote/sample_code_fake_api/sample_code_fake_api_remote.dart'
+    as _i198;
+import 'package:data/data/repositories/comment/comment_repository_impl.dart'
+    as _i576;
+import 'package:data/data/repositories/crash_log/crash_log_repository_impl.dart'
+    as _i701;
+import 'package:data/domain/repositories/comment/comment_repository.dart'
+    as _i683;
+import 'package:data/domain/repositories/crash_log/crash_log_repository.dart'
+    as _i63;
+import 'package:data/domain/repositories/sample_code_fake_api/sample_code_fake_api_repositories.dart'
+    as _i872;
+import 'package:data/domain/usecases/upload_pending_crash_logs_usecase.dart'
+    as _i813;
+import 'package:dio/dio.dart' as _i361;
+import 'package:get_it/get_it.dart' as _i174;
+import 'package:injectable/injectable.dart' as _i526;
+
+extension GetItInjectableX on _i174.GetIt {
+  // initializes the registration of main-scope dependencies inside of GetIt
+  _i174.GetIt $initModuleGetIt({
+    String? environment,
+    _i526.EnvironmentFilter? environmentFilter,
+  }) {
+    final gh = _i526.GetItHelper(this, environment, environmentFilter);
+    final dataModule = _$DataModule();
+    gh.singleton<Iterable<_i361.Interceptor>>(() => dataModule.ccInterceptors);
+    gh.singleton<_i361.Interceptor>(() => dataModule.ccReqInterceptors);
+    gh.lazySingleton<_i198.SampleCodeFakeApiRemote>(
+      () => _i198.SampleCodeFakeApiRemote(
+        gh<_i361.Dio>(),
+        baseUrl: gh<String>(instanceName: 'baseUrl'),
+      ),
+    );
+    gh.factory<Map<String, dynamic>>(
+      () => dataModule.wrapListResponse(gh<List<dynamic>>()),
+    );
+    gh.lazySingleton<_i872.SampleCodeFakeApiRepositories>(
+      () => _i872.SampleCodeFakeApiImpl(
+        dio: gh<_i361.Dio>(),
+        remote: gh<_i198.SampleCodeFakeApiRemote>(),
+      ),
+    );
+    gh.factory<String>(() => dataModule.baseUrl, instanceName: 'baseUrl');
+    gh.singleton<_i361.Dio>(
+      () => dataModule.dio(gh<String>(instanceName: 'baseUrl')),
+      instanceName: 'baseDio',
+    );
+    gh.singleton<_i574.CommentRemote>(
+      () => _i574.CommentRemote(gh<_i361.Dio>(instanceName: 'baseDio')),
+    );
+    gh.singleton<_i683.CommentRepository>(
+      () =>
+          _i576.CommentRepositoryImpl(commentRemote: gh<_i574.CommentRemote>()),
+    );
+    gh.lazySingleton<_i313.CrashLogRemote>(
+      () => _i313.CrashLogRemote(gh<_i361.Dio>(instanceName: 'baseDio')),
+    );
+    gh.lazySingleton<_i63.CrashLogRepository>(
+      () => _i701.CrashLogRepositoryImpl(gh<_i313.CrashLogRemote>()),
+    );
+    gh.lazySingleton<_i813.UploadPendingCrashLogsUseCase>(
+      () => _i813.UploadPendingCrashLogsUseCase(gh<_i63.CrashLogRepository>()),
+    );
+    return this;
+  }
+}
+
+class _$DataModule extends _i532.DataModule {}


### PR DESCRIPTION
## Summary

Fixes the `$initCcSdkDependencies` "function not defined" error in `di_cc_sdk.config.dart` and the same issue across all other modules.

**Root cause:** The `.gitignore` contained `**/*.config.dart` (line 85), which prevented all `injectable_generator`-produced config files from being tracked in git. Anyone cloning the repo without running `build_runner` first would hit "function not defined" errors.

**Changes:**
- Commented out `**/*.config.dart` in `.gitignore` so DI config files are now tracked
- Generated and committed all 5 missing `.config.dart` files via `build_runner`:
  - `libraries/cc_sdk/lib/core/di/di_cc_sdk.config.dart` — defines `$initCcSdkDependencies`
  - `modules/app_config/lib/core/di/di_app_config.config.dart` — defines `$initAppConfigDependencies`
  - `modules/data/lib/core/di/inject/data_inject.config.dart` — defines `$initModuleGetIt`
  - `lib/core/di/inject/inject.config.dart` — defines `$initGetIt`
  - `libraries/features/lib/core/di/injection.config.dart` — defines `$initFeaturesGetIt`

## Review & Testing Checklist for Human

- [ ] After merging, pull the latest `main` and verify the project compiles without running `build_runner` — no "function not defined" errors for any `$init*Dependencies` function
- [ ] Run `flutter pub run build_runner build` in each module to confirm the generated files match what's committed (no diff)
- [ ] Verify that `**/*.g.dart` and `**/*.freezed.dart` still being gitignored is intentional and those files are always regenerated locally

### Notes

- The `.g.dart` files (retrofit, json_serializable, hive) are still gitignored. If you also want those committed, the same `.gitignore` change can be applied to `**/*.g.dart`.
- After any change to `@injectable` / `@module` annotated classes, you'll need to re-run `build_runner` and commit the updated `.config.dart` files.

Link to Devin session: https://app.devin.ai/sessions/586c330e450247ce98849fa4c597e037
Requested by: @huytower