### PR TITLE
refactor: clean up route_strategy — AutoRoute only, DI, subscribe pattern

### DIFF
--- a/lib/core/di/inject/inject.config.dart
+++ b/lib/core/di/inject/inject.config.dart
@@ -41,7 +41,6 @@ import '../../../sample_code/bloc_simple_page/origin/advance/advance_bloc.dart'
     as _i403;
 import '../../../sample_code/getx_simple_page/way_1/getx/get_view_controller.dart'
     as _i313;
-import '../../navigation/route_strategy_provider.dart' as _i740;
 import '../module/infrastructure_module.dart' as _i450;
 import '../module/route_strategy_module.dart' as _i210;
 
@@ -69,17 +68,6 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i602.RoutingStrategy>(
       () => _i602.AutoRouteStrategy(gh<_i901.ThemeProvider>()),
-      instanceName: 'autoRoute',
-    );
-    gh.lazySingleton<_i602.RoutingStrategy>(
-      () => _i602.GetXRouteStrategy(gh<_i901.ThemeProvider>()),
-      instanceName: 'getX',
-    );
-    gh.lazySingleton<_i740.RouteStrategyProvider>(
-      () => _i740.RouteStrategyProvider(
-        gh<_i602.RoutingStrategy>(instanceName: 'autoRoute'),
-        gh<_i602.RoutingStrategy>(instanceName: 'getX'),
-      ),
     );
     await gh.singletonAsync<_i54.CcDeviceEntity>(
       () => infrastructureModule.deviceModel(gh<_i833.DeviceInfoPlugin>()),

--- a/lib/core/di/inject/inject.config.dart
+++ b/lib/core/di/inject/inject.config.dart
@@ -26,7 +26,9 @@ import 'package:device_info_plus/device_info_plus.dart' as _i833;
 import 'package:features/core/di/injection.module.dart' as _i168;
 import 'package:get_it/get_it.dart' as _i174;
 import 'package:injectable/injectable.dart' as _i526;
+import 'package:theme/presentation/provider/theme_provider.dart' as _i901;
 
+import '../../../data/datasource/route_strategy.dart' as _i602;
 import '../../../presentation/getx/comment/get_x/comment_controller.dart'
     as _i551;
 import '../../../presentation/getx/web/get_x/web_controller.dart' as _i523;
@@ -39,7 +41,9 @@ import '../../../sample_code/bloc_simple_page/origin/advance/advance_bloc.dart'
     as _i403;
 import '../../../sample_code/getx_simple_page/way_1/getx/get_view_controller.dart'
     as _i313;
+import '../../navigation/route_strategy_provider.dart' as _i740;
 import '../module/infrastructure_module.dart' as _i450;
+import '../module/route_strategy_module.dart' as _i210;
 
 extension GetItInjectableX on _i174.GetIt {
   // initializes the registration of main-scope dependencies inside of GetIt
@@ -53,12 +57,30 @@ extension GetItInjectableX on _i174.GetIt {
     await _i72.AppConfigPackageModule().init(gh);
     await _i168.FeaturesPackageModule().init(gh);
     final infrastructureModule = _$InfrastructureModule();
+    final routeStrategyModule = _$RouteStrategyModule();
     gh.factory<_i551.CommentBinding>(() => _i551.CommentBinding());
     gh.factory<_i523.WebBinding>(() => _i523.WebBinding());
     gh.factory<_i523.WebController>(() => _i523.WebController());
     gh.factory<_i313.GetViewBinding>(() => _i313.GetViewBinding());
     gh.lazySingleton<_i403.AdvanceBloc>(() => _i403.AdvanceBloc());
     gh.lazySingleton<_i439.SimpleCubitInterface>(() => _i271.SimpleCubit());
+    gh.lazySingleton<_i901.ThemeProvider>(
+      () => routeStrategyModule.provideThemeProvider(),
+    );
+    gh.lazySingleton<_i602.RoutingStrategy>(
+      () => _i602.AutoRouteStrategy(gh<_i901.ThemeProvider>()),
+      instanceName: 'autoRoute',
+    );
+    gh.lazySingleton<_i602.RoutingStrategy>(
+      () => _i602.GetXRouteStrategy(gh<_i901.ThemeProvider>()),
+      instanceName: 'getX',
+    );
+    gh.lazySingleton<_i740.RouteStrategyProvider>(
+      () => _i740.RouteStrategyProvider(
+        gh<_i602.RoutingStrategy>(instanceName: 'autoRoute'),
+        gh<_i602.RoutingStrategy>(instanceName: 'getX'),
+      ),
+    );
     await gh.singletonAsync<_i54.CcDeviceEntity>(
       () => infrastructureModule.deviceModel(gh<_i833.DeviceInfoPlugin>()),
       preResolve: true,
@@ -83,3 +105,5 @@ extension GetItInjectableX on _i174.GetIt {
 }
 
 class _$InfrastructureModule extends _i450.InfrastructureModule {}
+
+class _$RouteStrategyModule extends _i210.RouteStrategyModule {}

--- a/lib/core/di/module/route_strategy_module.dart
+++ b/lib/core/di/module/route_strategy_module.dart
@@ -1,0 +1,10 @@
+import 'package:injectable/injectable.dart';
+import 'package:theme/presentation/provider/theme_provider.dart';
+
+/// Provides routing-layer dependencies that originate from external packages.
+@module
+abstract class RouteStrategyModule {
+  /// Single [ThemeProvider] instance shared across all routing strategies.
+  @lazySingleton
+  ThemeProvider provideThemeProvider() => ThemeProvider();
+}

--- a/lib/core/navigation/route_strategy_provider.dart
+++ b/lib/core/navigation/route_strategy_provider.dart
@@ -1,41 +1,9 @@
-import 'package:app_config/core/enum/routing_manager_enum.dart';
 import 'package:flutter/material.dart';
-import 'package:injectable/injectable.dart';
 
 import '../../data/datasource/route_strategy.dart';
 import '../di/inject/inject.dart';
 
-/// Resolves the active [RoutingStrategy] for a given [RoutingManagerEnum].
-///
-/// Both strategy implementations are injected by the DI container so this
-/// class has no hard-coded instantiation.
-@lazySingleton
-class RouteStrategyProvider {
-  final Map<RoutingManagerEnum, RoutingStrategy> _strategies;
-
-  RouteStrategyProvider(
-    @Named('autoRoute') RoutingStrategy autoRouteStrategy,
-    @Named('getX') RoutingStrategy getXStrategy,
-  ) : _strategies = {
-          RoutingManagerEnum.AUTO_ROUTE: autoRouteStrategy,
-          RoutingManagerEnum.GETX: getXStrategy,
-        };
-
-  /// Returns the strategy for [manager], falling back to AutoRoute.
-  RoutingStrategy getStrategy(RoutingManagerEnum manager) {
-    return _strategies[manager] ?? _strategies[RoutingManagerEnum.AUTO_ROUTE]!;
-  }
-
-  /// Disposes every registered strategy.
-  void disposeAll() {
-    for (final strategy in _strategies.values) {
-      strategy.dispose();
-    }
-  }
-}
-
-/// Convenience — builds the app widget for the given routing manager.
-Widget buildAppByRoutingManager(RoutingManagerEnum manager) {
-  final provider = getIt<RouteStrategyProvider>();
-  return provider.getStrategy(manager).buildApp();
+/// Builds the main app widget using the DI-registered [RoutingStrategy].
+Widget buildAppByRoutingStrategy() {
+  return getIt<RoutingStrategy>().buildApp();
 }

--- a/lib/core/navigation/route_strategy_provider.dart
+++ b/lib/core/navigation/route_strategy_provider.dart
@@ -1,31 +1,41 @@
 import 'package:app_config/core/enum/routing_manager_enum.dart';
 import 'package:flutter/material.dart';
+import 'package:injectable/injectable.dart';
 
 import '../../data/datasource/route_strategy.dart';
+import '../di/inject/inject.dart';
 
-/// Provides access to all available routing strategies
+/// Resolves the active [RoutingStrategy] for a given [RoutingManagerEnum].
+///
+/// Both strategy implementations are injected by the DI container so this
+/// class has no hard-coded instantiation.
+@lazySingleton
 class RouteStrategyProvider {
-  /// Gets the appropriate routing strategy based on the provided enum
-  static RoutingStrategy getStrategy(RoutingManagerEnum manager) {
-    return _routingStrategies[manager] ?? _getDefaultStrategy();
+  final Map<RoutingManagerEnum, RoutingStrategy> _strategies;
+
+  RouteStrategyProvider(
+    @Named('autoRoute') RoutingStrategy autoRouteStrategy,
+    @Named('getX') RoutingStrategy getXStrategy,
+  ) : _strategies = {
+          RoutingManagerEnum.AUTO_ROUTE: autoRouteStrategy,
+          RoutingManagerEnum.GETX: getXStrategy,
+        };
+
+  /// Returns the strategy for [manager], falling back to AutoRoute.
+  RoutingStrategy getStrategy(RoutingManagerEnum manager) {
+    return _strategies[manager] ?? _strategies[RoutingManagerEnum.AUTO_ROUTE]!;
   }
 
-  /// Gets the default routing strategy
-  static RoutingStrategy _getDefaultStrategy() {
-    return _routingStrategies[RoutingManagerEnum.AUTO_ROUTE]!;
+  /// Disposes every registered strategy.
+  void disposeAll() {
+    for (final strategy in _strategies.values) {
+      strategy.dispose();
+    }
   }
-
-  /// Map of all available routing strategies
-  static final Map<RoutingManagerEnum, RoutingStrategy> _routingStrategies = {
-    RoutingManagerEnum.AUTO_ROUTE: AutoRouteStrategy(),
-    RoutingManagerEnum.GETX: GetxRouteStrategy(),
-  };
 }
 
-/// Returns the main app UI for the given navigate manager
-///
-/// Throws [UnimplementedError] if the routing manager is not supported
+/// Convenience — builds the app widget for the given routing manager.
 Widget buildAppByRoutingManager(RoutingManagerEnum manager) {
-  final strategy = RouteStrategyProvider.getStrategy(manager);
-  return strategy.build();
+  final provider = getIt<RouteStrategyProvider>();
+  return provider.getStrategy(manager).buildApp();
 }

--- a/lib/core/runner/app_runner.dart
+++ b/lib/core/runner/app_runner.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 
-import '../../data/datasource/route_datasource.dart';
+import '../../data/datasource/route_strategy.dart';
 import '../common/managers/hive_manager.dart';
 import '../di/inject/inject.dart';
-import '../navigation/route_strategy_provider.dart';
 
 class AppRunner extends StatefulWidget {
   const AppRunner({super.key});
@@ -14,24 +13,22 @@ class AppRunner extends StatefulWidget {
 
 class AppRunnerState extends State<AppRunner> {
   late final HiveManager _hiveManager;
-  late final RouteStrategyProvider _routeStrategyProvider;
+  late final RoutingStrategy _routingStrategy;
 
   @override
   void initState() {
     super.initState();
-    _routeStrategyProvider = getIt<RouteStrategyProvider>();
+    _routingStrategy = getIt<RoutingStrategy>();
   }
 
   @override
   Widget build(BuildContext context) {
-    return _routeStrategyProvider
-        .getStrategy(RouteDatasource.currentStrategy)
-        .buildApp();
+    return _routingStrategy.buildApp();
   }
 
   @override
   void dispose() {
-    _routeStrategyProvider.disposeAll();
+    _routingStrategy.dispose();
     _hiveManager.closeBoxes();
     super.dispose();
   }

--- a/lib/core/runner/app_runner.dart
+++ b/lib/core/runner/app_runner.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../data/datasource/route_datasource.dart';
 import '../common/managers/hive_manager.dart';
+import '../di/inject/inject.dart';
 import '../navigation/route_strategy_provider.dart';
 
 class AppRunner extends StatefulWidget {
@@ -13,20 +14,24 @@ class AppRunner extends StatefulWidget {
 
 class AppRunnerState extends State<AppRunner> {
   late final HiveManager _hiveManager;
+  late final RouteStrategyProvider _routeStrategyProvider;
+
+  @override
+  void initState() {
+    super.initState();
+    _routeStrategyProvider = getIt<RouteStrategyProvider>();
+  }
 
   @override
   Widget build(BuildContext context) {
-    return buildBody();
-  }
-
-  /// Builds the main app ui according to the selected navigate strategy.
-  /// Delegates to [buildAppByRoutingManager] in route_strategy.dart for functional clarity.
-  Widget buildBody() {
-    return buildAppByRoutingManager(RouteDatasource.currentStrategy);
+    return _routeStrategyProvider
+        .getStrategy(RouteDatasource.currentStrategy)
+        .buildApp();
   }
 
   @override
   void dispose() {
+    _routeStrategyProvider.disposeAll();
     _hiveManager.closeBoxes();
     super.dispose();
   }

--- a/lib/data/datasource/route_datasource.dart
+++ b/lib/data/datasource/route_datasource.dart
@@ -5,7 +5,8 @@ import '../../core/navigation/enums/page_name_enum.dart';
 /// Handles application routing configuration and route resolution
 class RouteDatasource {
   // Private constants
-  static const RoutingManagerEnum _currentStrategy = RoutingManagerEnum.GETX;
+  static const RoutingManagerEnum _currentStrategy =
+      RoutingManagerEnum.AUTO_ROUTE;
   static const PageNameEnum _defaultStartRoute = PageNameEnum.COMMENT;
   // static const PageNameEnum _defaultStartRoute = PageNameEnum.HOME;
 

--- a/lib/data/datasource/route_strategy.dart
+++ b/lib/data/datasource/route_strategy.dart
@@ -4,15 +4,12 @@ import 'package:catcher_2/catcher_2.dart';
 import 'package:cc_sdk/export_cc_sdk.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
 import 'package:injectable/injectable.dart';
 import 'package:provider/provider.dart';
 import 'package:theme/core/utils/theme_utils.dart';
 import 'package:theme/presentation/provider/theme_provider.dart';
 
 import '../../core/navigation/config/auto_route/app_router.dart';
-import '../../core/navigation/config/getx/getx_router.dart';
-import '../../core/navigation/enums/page_name_enum.dart';
 
 // ---------------------------------------------------------------------------
 // Base
@@ -20,9 +17,9 @@ import '../../core/navigation/enums/page_name_enum.dart';
 
 /// Contract for routing strategies.
 ///
-/// Subclasses supply a specific router widget (e.g. [MaterialApp.router],
-/// [GetMaterialApp]). The shared theme / localisation wiring lives in
-/// [buildThemedApp] and is written only once.
+/// Subclasses supply a specific router widget (e.g. [MaterialApp.router]).
+/// The shared theme / localisation wiring lives in [buildThemedApp] and is
+/// written only once.
 abstract class RoutingStrategy {
   final ThemeProvider _themeProvider;
 
@@ -87,7 +84,6 @@ abstract class RoutingStrategy {
 // ---------------------------------------------------------------------------
 
 /// [RoutingStrategy] backed by the `auto_route` package.
-@Named('autoRoute')
 @LazySingleton(as: RoutingStrategy)
 class AutoRouteStrategy extends RoutingStrategy {
   AutoRouteStrategy(ThemeProvider themeProvider) : super(themeProvider);
@@ -101,35 +97,6 @@ class AutoRouteStrategy extends RoutingStrategy {
         darkTheme: createDarkTheme(),
         themeMode: themeProvider.themeMode,
         routerConfig: AppRouter(navigatorKey: Catcher2.navigatorKey).config(),
-        locale: CcLocalization.getCurrentLocale(context),
-        localizationsDelegates: context.localizationDelegates,
-        supportedLocales: context.supportedLocales,
-      );
-    });
-  }
-}
-
-// ---------------------------------------------------------------------------
-// GetX implementation
-// ---------------------------------------------------------------------------
-
-/// [RoutingStrategy] backed by the `GetX` package.
-@Named('getX')
-@LazySingleton(as: RoutingStrategy)
-class GetXRouteStrategy extends RoutingStrategy {
-  GetXRouteStrategy(ThemeProvider themeProvider) : super(themeProvider);
-
-  @override
-  Widget buildApp() {
-    return buildThemedApp((context, themeProvider) {
-      return GetMaterialApp(
-        navigatorKey: Catcher2.navigatorKey,
-        debugShowCheckedModeBanner: false,
-        theme: createLightTheme(),
-        darkTheme: createDarkTheme(),
-        themeMode: themeProvider.themeMode,
-        initialRoute: getPageName(PageNameEnum.SPLASH),
-        getPages: GetxRoutingManager.instance.getPages(),
         locale: CcLocalization.getCurrentLocale(context),
         localizationsDelegates: context.localizationDelegates,
         supportedLocales: context.supportedLocales,

--- a/lib/data/datasource/route_strategy.dart
+++ b/lib/data/datasource/route_strategy.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:catcher_2/catcher_2.dart';
 import 'package:cc_sdk/export_cc_sdk.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:injectable/injectable.dart';
 import 'package:provider/provider.dart';
 import 'package:theme/core/utils/theme_utils.dart';
 import 'package:theme/presentation/provider/theme_provider.dart';
@@ -11,41 +14,66 @@ import '../../core/navigation/config/auto_route/app_router.dart';
 import '../../core/navigation/config/getx/getx_router.dart';
 import '../../core/navigation/enums/page_name_enum.dart';
 
-/// Abstract base class for different routing strategies
+// ---------------------------------------------------------------------------
+// Base
+// ---------------------------------------------------------------------------
+
+/// Contract for routing strategies.
+///
+/// Subclasses supply a specific router widget (e.g. [MaterialApp.router],
+/// [GetMaterialApp]). The shared theme / localisation wiring lives in
+/// [buildThemedApp] and is written only once.
 abstract class RoutingStrategy {
-  /// Builds the application with the appropriate routing configuration
-  Widget build();
-}
+  final ThemeProvider _themeProvider;
 
-/// Implementation of RoutingStrategy using AutoRoute
-class AutoRouteStrategy implements RoutingStrategy {
-  @override
-  Widget build() {
-    return _buildThemedApp(
-      routerConfig: AppRouter(navigatorKey: Catcher2.navigatorKey).config(),
-    );
+  final StreamController<ThemeMode> _themeModeController =
+      StreamController<ThemeMode>.broadcast();
+
+  late final VoidCallback _themeListener;
+
+  RoutingStrategy(this._themeProvider) {
+    _themeListener = () => _themeModeController.add(_themeProvider.themeMode);
+    _themeProvider.addListener(_themeListener);
   }
 
-  /// Builds the MaterialApp with theme and localization support
-  Widget _buildThemedApp({required dynamic routerConfig}) {
-    return ChangeNotifierProvider(
-      create: (_) => ThemeProvider(),
+  // -- public API -----------------------------------------------------------
+
+  /// Builds the fully-configured application widget.
+  Widget buildApp();
+
+  /// Reactive stream of [ThemeMode] updates — use with `listen` / `StreamBuilder`.
+  Stream<ThemeMode> get themeModeChanges => _themeModeController.stream;
+
+  /// Subscribes [listener] to theme changes.
+  /// Returns an *unsubscribe* callback for easy cleanup.
+  VoidCallback onThemeChanged(VoidCallback listener) {
+    _themeProvider.addListener(listener);
+    return () => _themeProvider.removeListener(listener);
+  }
+
+  /// Releases resources held by this strategy.
+  @mustCallSuper
+  void dispose() {
+    _themeProvider.removeListener(_themeListener);
+    _themeModeController.close();
+  }
+
+  // -- shared builder -------------------------------------------------------
+
+  /// Wraps [routerBuilder] with the common [ChangeNotifierProvider],
+  /// [Consumer<ThemeProvider>], and [CcLocalization] layers.
+  @protected
+  Widget buildThemedApp(
+    Widget Function(BuildContext context, ThemeProvider themeProvider)
+        routerBuilder,
+  ) {
+    return ChangeNotifierProvider<ThemeProvider>.value(
+      value: _themeProvider,
       child: Consumer<ThemeProvider>(
         builder: (context, themeProvider, _) {
           return CcLocalization.wrapWithLocalization(
             child: Builder(
-              builder: (context) {
-                return MaterialApp.router(
-                  debugShowCheckedModeBanner: false,
-                  theme: createLightTheme(),
-                  darkTheme: createDarkTheme(),
-                  themeMode: themeProvider.themeMode,
-                  routerConfig: routerConfig,
-                  locale: CcLocalization.getCurrentLocale(context),
-                  localizationsDelegates: context.localizationDelegates,
-                  supportedLocales: context.supportedLocales,
-                );
-              },
+              builder: (context) => routerBuilder(context, themeProvider),
             ),
           );
         },
@@ -54,45 +82,58 @@ class AutoRouteStrategy implements RoutingStrategy {
   }
 }
 
-/// Implementation of RoutingStrategy using GetX
-class GetxRouteStrategy implements RoutingStrategy {
-  @override
-  Widget build() {
-    return _buildThemedApp(
-      initialRoute: getPageName(PageNameEnum.SPLASH),
-      getPages: GetxRoutingManager.instance.getPages(),
-    );
-  }
+// ---------------------------------------------------------------------------
+// AutoRoute implementation
+// ---------------------------------------------------------------------------
 
-  /// Builds the GetMaterialApp with theme and localization support
-  Widget _buildThemedApp({
-    required String initialRoute,
-    required List<GetPage> getPages,
-  }) {
-    return ChangeNotifierProvider(
-      create: (_) => ThemeProvider(),
-      child: Consumer<ThemeProvider>(
-        builder: (context, themeProvider, _) {
-          return CcLocalization.wrapWithLocalization(
-            child: Builder(
-              builder: (context) {
-                return GetMaterialApp(
-                  navigatorKey: Catcher2.navigatorKey,
-                  debugShowCheckedModeBanner: false,
-                  theme: createLightTheme(),
-                  darkTheme: createDarkTheme(),
-                  themeMode: themeProvider.themeMode,
-                  initialRoute: initialRoute,
-                  getPages: getPages,
-                  locale: CcLocalization.getCurrentLocale(context),
-                  localizationsDelegates: context.localizationDelegates,
-                  supportedLocales: context.supportedLocales,
-                );
-              },
-            ),
-          );
-        },
-      ),
-    );
+/// [RoutingStrategy] backed by the `auto_route` package.
+@Named('autoRoute')
+@LazySingleton(as: RoutingStrategy)
+class AutoRouteStrategy extends RoutingStrategy {
+  AutoRouteStrategy(ThemeProvider themeProvider) : super(themeProvider);
+
+  @override
+  Widget buildApp() {
+    return buildThemedApp((context, themeProvider) {
+      return MaterialApp.router(
+        debugShowCheckedModeBanner: false,
+        theme: createLightTheme(),
+        darkTheme: createDarkTheme(),
+        themeMode: themeProvider.themeMode,
+        routerConfig: AppRouter(navigatorKey: Catcher2.navigatorKey).config(),
+        locale: CcLocalization.getCurrentLocale(context),
+        localizationsDelegates: context.localizationDelegates,
+        supportedLocales: context.supportedLocales,
+      );
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GetX implementation
+// ---------------------------------------------------------------------------
+
+/// [RoutingStrategy] backed by the `GetX` package.
+@Named('getX')
+@LazySingleton(as: RoutingStrategy)
+class GetXRouteStrategy extends RoutingStrategy {
+  GetXRouteStrategy(ThemeProvider themeProvider) : super(themeProvider);
+
+  @override
+  Widget buildApp() {
+    return buildThemedApp((context, themeProvider) {
+      return GetMaterialApp(
+        navigatorKey: Catcher2.navigatorKey,
+        debugShowCheckedModeBanner: false,
+        theme: createLightTheme(),
+        darkTheme: createDarkTheme(),
+        themeMode: themeProvider.themeMode,
+        initialRoute: getPageName(PageNameEnum.SPLASH),
+        getPages: GetxRoutingManager.instance.getPages(),
+        locale: CcLocalization.getCurrentLocale(context),
+        localizationsDelegates: context.localizationDelegates,
+        supportedLocales: context.supportedLocales,
+      );
+    });
   }
 }


### PR DESCRIPTION
## Summary

Refactors `route_strategy.dart` to be clean, clear, and DI-injectable. **Removes GetX routing entirely** — only AutoRoute is kept.

### What changed

**1. Removed GetX routing**
- Deleted `GetXRouteStrategy` class and all GetX routing imports
- Changed `RouteDatasource._currentStrategy` from `GETX` → `AUTO_ROUTE`
- Removed `RouteStrategyProvider` (unnecessary with a single strategy)

**2. Eliminated code duplication** — The `_buildThemedApp()` boilerplate (theme provider + localization wrapper) is extracted into a single `buildThemedApp()` in the base `RoutingStrategy` class.

**3. DI via injectable**:
- `ThemeProvider` → `@lazySingleton` via new `RouteStrategyModule`
- `AutoRouteStrategy` → `@LazySingleton(as: RoutingStrategy)`
- `AppRunner` resolves `RoutingStrategy` directly from `getIt`

**4. Subscribe pattern** — Two subscription APIs on `RoutingStrategy`:
- `onThemeChanged(VoidCallback)` → listener-based, returns unsubscribe callback
- `themeModeChanges` → `Stream<ThemeMode>` for reactive `listen` / `StreamBuilder`

**5. Lifecycle** — `dispose()` properly removes listeners and closes the stream controller.

**6. Naming conventions**:
- `build()` → `buildApp()`
- `_buildThemedApp` → `buildThemedApp` (protected, in base class)

### Files changed
- `lib/data/datasource/route_strategy.dart` — Refactored (AutoRoute only)
- `lib/data/datasource/route_datasource.dart` — Strategy → `AUTO_ROUTE`
- `lib/core/di/module/route_strategy_module.dart` — New DI module for ThemeProvider
- `lib/core/navigation/route_strategy_provider.dart` — Simplified to utility function
- `lib/core/di/inject/inject.config.dart` — Updated registrations
- `lib/core/runner/app_runner.dart` — Direct DI resolution of RoutingStrategy

## Review & Testing Checklist for Human

- [ ] Run `flutter pub run build_runner build` to regenerate `inject.config.dart` and verify it matches
- [ ] Verify the app launches correctly with AutoRoute
- [ ] Test theme switching works (subscribe pattern should propagate changes)

### Notes
- `inject.config.dart` was manually updated. Running `build_runner` should produce matching output.
- `buildAppByRoutingStrategy()` utility kept in `route_strategy_provider.dart` for convenience.


Link to Devin session: https://app.devin.ai/sessions/9990f223259541d58795667f1a066170
Requested by: @huytower